### PR TITLE
feat: add chunk map info in engine

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -7,7 +7,6 @@ Ophelia keeps the frontend and backend split into a few clear layers:
 - `theme.rs`: shared design tokens and visual constants
 - `app.rs`: app-layer bridge between GPUI and the backend engine
 - `app_menu.rs` / `app_actions.rs`: app-level actions, shortcuts, and menu wiring
-- `platform/`: platform-specific window/chrome integration
 - `platform/`: shared OS integration such as window chrome and app path policy
 - `engine/`: download engine, persistence, and provider-specific backend logic
 - `ipc.rs`: local ingress for browser-extension download handoff
@@ -39,6 +38,7 @@ These names are intentional too:
 - `runtime control support`: active transfers can narrow their available controls once runtime facts are known, such as HTTP falling back to single-stream mode
 - `live transfer removal action`: whether a live row left the active surface because the transfer was cancelled or because the artifact was deleted
 - `destination policy`: backend-owned resolution of destination folders, collision behavior, and final-file commit semantics
+- `chunk map state`: HTTP-specific, active-transfer-only visualization state for the Transfers view that stays out of persistence and does not expose raw executor slot arrays
 
 ## Directory map
 
@@ -83,7 +83,7 @@ These names are intentional too:
 
 - `app.rs`: GPUI-facing download model, backend service owner, progress polling, and history bridge
     - current remove/delete behavior is backend-owned: the app bridge asks the engine to delete artifacts, removes the live row on engine notification, and keeps history intact
-    - also caches provider kind, source label, control support, and an `id -> index` side map for each live row
+    - also caches provider kind, source label, control support, HTTP chunk-map state, and an `id -> index` side map for each live row
     - backend notifications now distinguish cancel-transfer from delete-artifact even though the current UI still handles both as “remove the live row and refresh history”
     - backend state now supports a frontend model of one `Transfers` surface with internal status filters plus a separate global `History` surface
 - `ipc.rs`: local Axum server plus app-owned IPC ingress handle
@@ -99,7 +99,7 @@ These names are intentional too:
     - `spec.rs`: provider-neutral add/restore request shapes, ingress normalization, and settings-driven provider/config plus destination-policy mapping
     - `types.rs`: shared engine-facing types, persisted source/resume data, provider-aware history read models, progress updates, and engine notifications
     - `state/`: SQLite persistence, provider-kind-aware storage/bootstrap, provider-specific resume-state helpers, DB worker, and history reader
-    - `http/`: HTTP-specific executor pipeline
+    - `http/`: HTTP-specific executor pipeline, including live chunk-map snapshot reporting for active chunked transfers
 
 ## Placement rules
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,7 +40,7 @@ use crate::engine::state::{self, HistoryReader};
 use crate::engine::{
     AddDownloadRequest, ArtifactState, DownloadControlAction, DownloadEngine, DownloadId,
     DownloadSpec, DownloadStatus, EngineNotification, HistoryFilter, HistoryRow, ProgressUpdate,
-    RestoredDownload, SavedDownload, TransferControlSupport,
+    RestoredDownload, SavedDownload, TransferChunkMapState, TransferControlSupport,
 };
 use crate::ipc::IpcServer;
 use crate::settings::Settings;
@@ -64,6 +64,7 @@ pub struct Downloads {
     pub statuses: Vec<DownloadStatus>,
     /// Provider-declared lifecycle controls for each live transfer.
     pub control_supports: Vec<TransferControlSupport>,
+    pub transfer_chunk_maps: Vec<TransferChunkMapState>,
     pub downloaded_bytes: Vec<u64>,
     pub total_bytes: Vec<Option<u64>>,
     pub speeds: Vec<u64>,
@@ -258,6 +259,7 @@ impl Downloads {
             destinations: Vec::new(),
             statuses: Vec::new(),
             control_supports: Vec::new(),
+            transfer_chunk_maps: Vec::new(),
             downloaded_bytes: Vec::new(),
             total_bytes: Vec::new(),
             speeds: Vec::new(),
@@ -362,6 +364,8 @@ impl Downloads {
         self.destinations.push(dest_str);
         self.statuses.push(DownloadStatus::Pending);
         self.control_supports.push(control_support);
+        self.transfer_chunk_maps
+            .push(TransferChunkMapState::Unsupported);
         self.downloaded_bytes.push(0);
         self.total_bytes.push(None);
         self.speeds.push(0);
@@ -484,6 +488,11 @@ impl Downloads {
             .collect()
     }
 
+    #[allow(dead_code)] // reserved for the Transfers chunk bitmap card once the frontend consumes it.
+    pub fn transfer_chunk_map_state(&self, id: DownloadId) -> TransferChunkMapState {
+        transfer_chunk_map_state_or_unsupported(&self.transfer_chunk_maps, self.index_of(id))
+    }
+
     pub fn storage_summary(&self) -> SidebarStorageSummary {
         storage_summary_for_path(&self.settings.download_dir())
     }
@@ -529,6 +538,8 @@ impl Downloads {
         self.destinations.push(dest_str);
         self.statuses.push(DownloadStatus::Paused);
         self.control_supports.push(saved.source.control_support());
+        self.transfer_chunk_maps
+            .push(TransferChunkMapState::Unsupported);
         self.downloaded_bytes.push(saved.downloaded_bytes);
         self.total_bytes.push(saved.total_bytes);
         self.speeds.push(0);
@@ -585,6 +596,12 @@ impl Downloads {
                     cx.notify();
                 }
             }
+            EngineNotification::ChunkMapStateChanged { id, state } => {
+                if let Some(idx) = self.index_of(id) {
+                    self.transfer_chunk_maps[idx] = state;
+                    cx.notify();
+                }
+            }
             EngineNotification::LiveTransferRemoved {
                 id,
                 action,
@@ -619,6 +636,7 @@ impl Downloads {
             self.destinations.remove(idx);
             self.statuses.remove(idx);
             self.control_supports.remove(idx);
+            self.transfer_chunk_maps.remove(idx);
             self.downloaded_bytes.remove(idx);
             self.total_bytes.remove(idx);
             self.speeds.remove(idx);
@@ -681,6 +699,16 @@ fn build_row_index(ids: &[DownloadId]) -> HashMap<DownloadId, usize> {
         .enumerate()
         .map(|(index, id)| (id, index))
         .collect()
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+fn transfer_chunk_map_state_or_unsupported(
+    states: &[TransferChunkMapState],
+    index: Option<usize>,
+) -> TransferChunkMapState {
+    index
+        .and_then(|idx| states.get(idx).cloned())
+        .unwrap_or(TransferChunkMapState::Unsupported)
 }
 
 fn query_disk(path: &Path) -> (u64, u64) {
@@ -800,5 +828,28 @@ mod tests {
         assert_eq!(map.get(&DownloadId(7)), Some(&0));
         assert_eq!(map.get(&DownloadId(11)), Some(&1));
         assert_eq!(map.get(&DownloadId(3)), Some(&2));
+    }
+
+    #[test]
+    fn transfer_chunk_map_state_defaults_to_unsupported_for_missing_rows() {
+        let states = vec![TransferChunkMapState::Loading];
+
+        assert_eq!(
+            transfer_chunk_map_state_or_unsupported(&states, None),
+            TransferChunkMapState::Unsupported
+        );
+    }
+
+    #[test]
+    fn transfer_chunk_map_state_returns_stored_state_for_present_rows() {
+        let states = vec![
+            TransferChunkMapState::Unsupported,
+            TransferChunkMapState::Loading,
+        ];
+
+        assert_eq!(
+            transfer_chunk_map_state_or_unsupported(&states, Some(1)),
+            TransferChunkMapState::Loading
+        );
     }
 }

--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -51,7 +51,7 @@ use crate::engine::provider::{
 use crate::engine::{
     ArtifactState, DbEvent, DownloadControlAction, DownloadId, DownloadSpec, DownloadStatus,
     EngineNotification, LiveTransferRemovalAction, ProgressUpdate, ProviderResumeData,
-    RestoredDownload, TaskRuntimeUpdate, TransferControlSupport,
+    RestoredDownload, TaskRuntimeUpdate, TransferChunkMapState, TransferControlSupport,
 };
 use crate::settings::Settings;
 
@@ -363,6 +363,16 @@ impl EngineActor {
                 spec,
             },
         );
+        let _ = self
+            .notification_tx
+            .send(EngineNotification::ChunkMapStateChanged {
+                id,
+                state: self
+                    .tasks
+                    .get(&id)
+                    .map(|entry| entry.spec.active_chunk_map_state())
+                    .unwrap_or(TransferChunkMapState::Unsupported),
+            });
     }
 
     /// Pop queued tasks and spawn them until we hit max_concurrent or the queue is empty.
@@ -430,6 +440,12 @@ impl EngineActor {
                     downloaded_bytes,
                     resume_data: Some(resume_data.clone()),
                 });
+                let _ = self
+                    .notification_tx
+                    .send(EngineNotification::ChunkMapStateChanged {
+                        id,
+                        state: TransferChunkMapState::Unsupported,
+                    });
                 self.paused.insert(
                     id,
                     PausedTask {
@@ -447,6 +463,12 @@ impl EngineActor {
                 downloaded_bytes: 0,
                 resume_data: None,
             });
+            let _ = self
+                .notification_tx
+                .send(EngineNotification::ChunkMapStateChanged {
+                    id,
+                    state: TransferChunkMapState::Unsupported,
+                });
             let _ = self.notification_tx.send(self.status_notification(
                 id,
                 DownloadStatus::Paused,
@@ -532,6 +554,12 @@ impl EngineActor {
                 .send(DbEvent::ArtifactStateChanged { id, artifact_state });
             let _ = self
                 .notification_tx
+                .send(EngineNotification::ChunkMapStateChanged {
+                    id,
+                    state: TransferChunkMapState::Unsupported,
+                });
+            let _ = self
+                .notification_tx
                 .send(EngineNotification::LiveTransferRemoved {
                     id,
                     action: LiveTransferRemovalAction::Cancelled,
@@ -566,6 +594,12 @@ impl EngineActor {
             .send(DbEvent::ArtifactStateChanged { id, artifact_state });
         let _ = self
             .notification_tx
+            .send(EngineNotification::ChunkMapStateChanged {
+                id,
+                state: TransferChunkMapState::Unsupported,
+            });
+        let _ = self
+            .notification_tx
             .send(EngineNotification::LiveTransferRemoved {
                 id,
                 action: LiveTransferRemovalAction::DeleteArtifact,
@@ -598,6 +632,12 @@ impl EngineActor {
 
         match done.final_state.status {
             DownloadStatus::Finished => {
+                let _ = self
+                    .notification_tx
+                    .send(EngineNotification::ChunkMapStateChanged {
+                        id: done.id,
+                        state: TransferChunkMapState::Unsupported,
+                    });
                 let _ = self.db_tx.send(DbEvent::Finished {
                     id: done.id,
                     total_bytes: done
@@ -608,6 +648,12 @@ impl EngineActor {
                 self.try_start_next();
             }
             DownloadStatus::Error => {
+                let _ = self
+                    .notification_tx
+                    .send(EngineNotification::ChunkMapStateChanged {
+                        id: done.id,
+                        state: TransferChunkMapState::Unsupported,
+                    });
                 let _ = self.db_tx.send(DbEvent::Error { id: done.id });
                 self.try_start_next();
             }
@@ -666,6 +712,14 @@ impl EngineActor {
                 let _ = self
                     .notification_tx
                     .send(EngineNotification::ControlSupportChanged { id, support });
+            }
+            TaskRuntimeUpdate::ChunkMapStateChanged { id, state } => {
+                if !self.tasks.contains_key(&id) {
+                    return;
+                }
+                let _ = self
+                    .notification_tx
+                    .send(EngineNotification::ChunkMapStateChanged { id, state });
             }
         }
     }

--- a/src/engine/http/chunk_map.rs
+++ b/src/engine/http/chunk_map.rs
@@ -1,0 +1,255 @@
+/***************************************************
+** This file is part of Ophelia.
+** Copyright © 2026 Viktor Luna <viktor@hystericca.dev>
+** Released under the GPL License, version 3 or later.
+**
+** If you found a weird little bug in here, tell the cat:
+** viktor@hystericca.dev
+**
+**   ⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜⏜
+** ( bugs behave plz, we're all trying our best )
+**   ⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝⏝
+**   ○
+**     ○
+**       ／l、
+**     （ﾟ､ ｡ ７
+**       l  ~ヽ
+**       じしf_,)ノ
+**************************************************/
+
+//! HTTP chunk-map snapshots for the Transfers view.
+//!
+//! The executor keeps per-slot atomic counters for chunking, stealing, and
+//! hedging. This module converts those executor-shaped internals into a compact
+//! fixed-width read model that the app layer can hand to the frontend without
+//! leaking raw slot arrays across the boundary.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::Duration;
+
+use crate::engine::{
+    ChunkMapCellState, DownloadId, HttpChunkMapSnapshot, TaskRuntimeUpdate, TransferChunkMapState,
+};
+
+pub(crate) const HTTP_CHUNK_MAP_CELLS: usize = 128;
+const HTTP_CHUNK_MAP_INTERVAL_MS: u64 = 250;
+
+pub(crate) fn spawn_chunk_map_reporter(
+    id: DownloadId,
+    starts: Arc<Vec<AtomicU64>>,
+    ends: Arc<Vec<AtomicU64>>,
+    downloaded: Arc<Vec<AtomicU64>>,
+    slot_count: Arc<AtomicUsize>,
+    total_bytes: u64,
+    runtime_update_tx: mpsc::UnboundedSender<TaskRuntimeUpdate>,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut last: Option<HttpChunkMapSnapshot> = None;
+
+        loop {
+            let snapshot = snapshot_from_slot_arrays(
+                total_bytes,
+                &starts,
+                &ends,
+                &downloaded,
+                slot_count.load(Ordering::Relaxed),
+            );
+
+            if last.as_ref() != Some(&snapshot) {
+                last = Some(snapshot.clone());
+                if runtime_update_tx
+                    .send(TaskRuntimeUpdate::ChunkMapStateChanged {
+                        id,
+                        state: TransferChunkMapState::Http(snapshot),
+                    })
+                    .is_err()
+                {
+                    break;
+                }
+            }
+
+            tokio::time::sleep(Duration::from_millis(HTTP_CHUNK_MAP_INTERVAL_MS)).await;
+        }
+    })
+}
+
+pub(crate) fn snapshot_from_slot_arrays(
+    total_bytes: u64,
+    starts: &[AtomicU64],
+    ends: &[AtomicU64],
+    downloaded: &[AtomicU64],
+    populated_slots: usize,
+) -> HttpChunkMapSnapshot {
+    let populated = populated_slots
+        .min(starts.len())
+        .min(ends.len())
+        .min(downloaded.len());
+    let covered_ranges = (0..populated).filter_map(|index| {
+        let start = starts[index].load(Ordering::Relaxed);
+        let end = ends[index].load(Ordering::Relaxed);
+        let covered_end = start.saturating_add(downloaded[index].load(Ordering::Relaxed));
+        let clamped_end = covered_end.min(end);
+        (clamped_end > start).then_some((start, clamped_end))
+    });
+
+    snapshot_from_covered_ranges(total_bytes, covered_ranges)
+}
+
+fn snapshot_from_covered_ranges(
+    total_bytes: u64,
+    covered_ranges: impl IntoIterator<Item = (u64, u64)>,
+) -> HttpChunkMapSnapshot {
+    let merged = merge_ranges(covered_ranges);
+    let mut cells = Vec::with_capacity(HTTP_CHUNK_MAP_CELLS);
+
+    for index in 0..HTTP_CHUNK_MAP_CELLS {
+        let cell_start = scaled_boundary(total_bytes, index);
+        let cell_end = scaled_boundary(total_bytes, index + 1);
+
+        if cell_end <= cell_start {
+            cells.push(ChunkMapCellState::Empty);
+            continue;
+        }
+
+        let covered = covered_len_in_range(&merged, cell_start, cell_end);
+        let cell_width = cell_end - cell_start;
+        let state = if covered == 0 {
+            ChunkMapCellState::Empty
+        } else if covered >= cell_width {
+            ChunkMapCellState::Complete
+        } else {
+            ChunkMapCellState::Partial
+        };
+        cells.push(state);
+    }
+
+    HttpChunkMapSnapshot { total_bytes, cells }
+}
+
+fn scaled_boundary(total_bytes: u64, step: usize) -> u64 {
+    ((total_bytes as u128 * step as u128) / HTTP_CHUNK_MAP_CELLS as u128) as u64
+}
+
+fn merge_ranges(covered_ranges: impl IntoIterator<Item = (u64, u64)>) -> Vec<(u64, u64)> {
+    let mut ranges: Vec<(u64, u64)> = covered_ranges
+        .into_iter()
+        .filter(|(start, end)| end > start)
+        .collect();
+    ranges.sort_unstable_by_key(|&(start, _)| start);
+
+    let mut merged = Vec::with_capacity(ranges.len());
+    for (start, end) in ranges {
+        if let Some((_, previous_end)) = merged.last_mut()
+            && start <= *previous_end
+        {
+            *previous_end = (*previous_end).max(end);
+            continue;
+        }
+        merged.push((start, end));
+    }
+
+    merged
+}
+
+fn covered_len_in_range(merged: &[(u64, u64)], start: u64, end: u64) -> u64 {
+    let mut covered = 0u64;
+    for &(range_start, range_end) in merged {
+        if range_end <= start {
+            continue;
+        }
+        if range_start >= end {
+            break;
+        }
+        let overlap_start = range_start.max(start);
+        let overlap_end = range_end.min(end);
+        if overlap_end > overlap_start {
+            covered += overlap_end - overlap_start;
+        }
+    }
+    covered
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn complete_cells(snapshot: &HttpChunkMapSnapshot) -> usize {
+        snapshot
+            .cells
+            .iter()
+            .filter(|&&cell| cell == ChunkMapCellState::Complete)
+            .count()
+    }
+
+    #[test]
+    fn empty_coverage_yields_empty_cells() {
+        let snapshot = snapshot_from_covered_ranges(1_280, std::iter::empty());
+        assert_eq!(snapshot.cells.len(), HTTP_CHUNK_MAP_CELLS);
+        assert!(
+            snapshot
+                .cells
+                .iter()
+                .all(|&cell| cell == ChunkMapCellState::Empty)
+        );
+    }
+
+    #[test]
+    fn full_coverage_yields_complete_cells() {
+        let snapshot = snapshot_from_covered_ranges(128, [(0, 128)]);
+        assert!(
+            snapshot
+                .cells
+                .iter()
+                .all(|&cell| cell == ChunkMapCellState::Complete)
+        );
+    }
+
+    #[test]
+    fn partial_coverage_marks_partial_cells() {
+        let snapshot = snapshot_from_covered_ranges(1_280, [(0, 5)]);
+        assert_eq!(snapshot.cells[0], ChunkMapCellState::Partial);
+        assert!(
+            snapshot.cells[1..]
+                .iter()
+                .all(|&cell| cell == ChunkMapCellState::Empty)
+        );
+    }
+
+    #[test]
+    fn resumed_chunk_progress_seeds_initial_coverage() {
+        let snapshot = snapshot_from_covered_ranges(1_280, [(0, 640), (640, 965)]);
+        assert_eq!(complete_cells(&snapshot), 96);
+        assert_eq!(snapshot.cells[96], ChunkMapCellState::Partial);
+        assert!(
+            snapshot.cells[97..]
+                .iter()
+                .all(|&cell| cell == ChunkMapCellState::Empty)
+        );
+    }
+
+    #[test]
+    fn overlapping_hedge_ranges_do_not_overcount() {
+        let snapshot = snapshot_from_covered_ranges(128, [(0, 64), (32, 96)]);
+        assert_eq!(complete_cells(&snapshot), 96);
+        assert!(
+            snapshot.cells[96..]
+                .iter()
+                .all(|&cell| cell == ChunkMapCellState::Empty)
+        );
+    }
+
+    #[test]
+    fn stolen_ranges_render_as_contiguous_coverage() {
+        let snapshot = snapshot_from_covered_ranges(128, [(0, 32), (32, 64), (64, 96)]);
+        assert_eq!(complete_cells(&snapshot), 96);
+        assert!(
+            snapshot.cells[96..]
+                .iter()
+                .all(|&cell| cell == ChunkMapCellState::Empty)
+        );
+    }
+}

--- a/src/engine/http/mod.rs
+++ b/src/engine/http/mod.rs
@@ -25,6 +25,7 @@ pub mod config;
 pub mod task;
 pub mod throttle;
 
+mod chunk_map;
 mod error;
 mod health;
 mod probe;

--- a/src/engine/http/task.rs
+++ b/src/engine/http/task.rs
@@ -50,6 +50,7 @@ use crate::engine::types::{
     TransferControlSupport,
 };
 
+use super::chunk_map::spawn_chunk_map_reporter;
 use super::error::{ChunkError, ChunkOutcome};
 use super::health::{activation_now, spawn_health_monitor};
 use super::probe::probe;
@@ -94,6 +95,7 @@ struct ResolvedChunks {
     part_path: PathBuf,
     destination: PathBuf,
     finalize_strategy: FinalizeStrategy,
+    chunk_map_supported: bool,
 }
 
 async fn resolve_chunks(
@@ -159,6 +161,7 @@ async fn resolve_chunks(
                 part_path,
                 destination,
                 finalize_strategy: destination_policy.finalize_strategy(),
+                chunk_map_supported: true,
             })
         }
         None => {
@@ -210,6 +213,10 @@ async fn resolve_chunks(
                         id,
                         support: single_stream_control_support(),
                     });
+                    let _ = runtime_update_tx.send(TaskRuntimeUpdate::ChunkMapStateChanged {
+                        id,
+                        state: crate::engine::TransferChunkMapState::Unsupported,
+                    });
                     return Err(single_download(
                         id,
                         Arc::clone(chunk_client),
@@ -259,6 +266,12 @@ async fn resolve_chunks(
 
             tracing::info!(total_bytes, num_chunks, "starting chunked download");
             let chunks = chunk::split(total_bytes, num_chunks);
+            if !probe_result.accepts_ranges {
+                let _ = runtime_update_tx.send(TaskRuntimeUpdate::ChunkMapStateChanged {
+                    id,
+                    state: crate::engine::TransferChunkMapState::Unsupported,
+                });
+            }
             Ok(ResolvedChunks {
                 total_bytes,
                 chunks,
@@ -266,6 +279,7 @@ async fn resolve_chunks(
                 part_path,
                 destination,
                 finalize_strategy,
+                chunk_map_supported: probe_result.accepts_ranges,
             })
         }
     }
@@ -587,6 +601,7 @@ pub async fn download_task(
         part_path,
         destination,
         finalize_strategy,
+        chunk_map_supported,
     } = resolved;
 
     let file = Arc::new(file);
@@ -664,6 +679,17 @@ pub async fn download_task(
         progress_interval_ms,
         progress_tx.clone(),
     );
+    let chunk_map_handle = chunk_map_supported.then(|| {
+        spawn_chunk_map_reporter(
+            id,
+            Arc::clone(&slots.starts),
+            Arc::clone(&slots.ends),
+            Arc::clone(&slots.downloaded),
+            Arc::clone(&slots.next_slot),
+            total_bytes,
+            runtime_update_tx.clone(),
+        )
+    });
 
     let health_handle = spawn_health_monitor(
         Arc::clone(&slots.downloaded),
@@ -784,6 +810,9 @@ pub async fn download_task(
     }
 
     progress_handle.abort();
+    if let Some(handle) = chunk_map_handle {
+        handle.abort();
+    }
     health_handle.abort();
     drop(file); // close before rename on Windows
 

--- a/src/engine/spec.rs
+++ b/src/engine/spec.rs
@@ -30,7 +30,8 @@ use crate::engine::destination::{
 };
 use crate::engine::http::HttpDownloadConfig;
 use crate::engine::types::{
-    DownloadId, PersistedDownloadSource, ProviderResumeData, SavedDownload, TransferControlSupport,
+    DownloadId, PersistedDownloadSource, ProviderResumeData, SavedDownload, TransferChunkMapState,
+    TransferControlSupport,
 };
 use crate::settings::Settings;
 
@@ -182,6 +183,10 @@ impl DownloadSpec {
     pub fn control_support(&self) -> TransferControlSupport {
         self.source.control_support()
     }
+
+    pub fn active_chunk_map_state(&self) -> TransferChunkMapState {
+        self.source.active_chunk_map_state()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -214,6 +219,12 @@ impl DownloadSource {
     pub fn control_support(&self) -> TransferControlSupport {
         match self {
             Self::Http { .. } => TransferControlSupport::all(),
+        }
+    }
+
+    pub fn active_chunk_map_state(&self) -> TransferChunkMapState {
+        match self {
+            Self::Http { .. } => TransferChunkMapState::Loading,
         }
     }
 }

--- a/src/engine/types.rs
+++ b/src/engine/types.rs
@@ -85,6 +85,26 @@ pub enum ArtifactState {
     Missing,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChunkMapCellState {
+    Empty,
+    Partial,
+    Complete,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HttpChunkMapSnapshot {
+    pub total_bytes: u64,
+    pub cells: Vec<ChunkMapCellState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TransferChunkMapState {
+    Unsupported,
+    Loading,
+    Http(HttpChunkMapSnapshot),
+}
+
 /// Events emitted by the engine actor and app layer, consumed by the DbEventWorker.
 /// The worker is the sole writer to SQLite and nothing else touches the DB.
 pub enum DbEvent {
@@ -293,6 +313,10 @@ pub enum EngineNotification {
         id: DownloadId,
         support: TransferControlSupport,
     },
+    ChunkMapStateChanged {
+        id: DownloadId,
+        state: TransferChunkMapState,
+    },
     LiveTransferRemoved {
         id: DownloadId,
         action: LiveTransferRemovalAction,
@@ -325,5 +349,9 @@ pub enum TaskRuntimeUpdate {
     ControlSupportChanged {
         id: DownloadId,
         support: TransferControlSupport,
+    },
+    ChunkMapStateChanged {
+        id: DownloadId,
+        state: TransferChunkMapState,
     },
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -17,6 +17,8 @@
 **       じしf_,)ノ
 **************************************************/
 
+#![allow(dead_code)]
+
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -70,6 +72,25 @@ pub async fn drain_progress(
 
 pub fn last_status(updates: &[ProgressUpdate]) -> Option<DownloadStatus> {
     updates.last().map(|u| u.status)
+}
+
+pub async fn wait_for_runtime_update(
+    rx: &mut mpsc::UnboundedReceiver<TaskRuntimeUpdate>,
+    mut predicate: impl FnMut(&TaskRuntimeUpdate) -> bool,
+) -> TaskRuntimeUpdate {
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+    loop {
+        if let Ok(update) = rx.try_recv()
+            && predicate(&update)
+        {
+            return update;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "timed out waiting for matching runtime update"
+        );
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/download_basic.rs
+++ b/tests/download_basic.rs
@@ -30,7 +30,8 @@ use wiremock::{Mock, MockServer, Respond, ResponseTemplate};
 
 use ophelia::engine::http::{HttpDownloadConfig, download_task};
 use ophelia::engine::types::{
-    DownloadId, DownloadStatus, TaskRuntimeUpdate, TransferControlSupport,
+    ChunkMapCellState, DownloadId, DownloadStatus, TaskRuntimeUpdate, TransferChunkMapState,
+    TransferControlSupport,
 };
 
 struct RangeDispositionResponder {
@@ -131,6 +132,73 @@ async fn parallel_download_with_range_support() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn chunked_http_emits_chunk_map_snapshot() {
+    let data = test_data(10_000);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/file.bin"))
+        .respond_with(RangeResponder { data: data.clone() })
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/file.bin", server.uri());
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("file.bin");
+
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let (runtime_tx, mut runtime_rx) = runtime_updates_channel();
+    download_task(
+        DownloadId(0),
+        url,
+        dest,
+        exact_destination_policy(&dir.path().join("file.bin")),
+        HttpDownloadConfig {
+            speed_limit_bps: 20_000,
+            write_buffer_size: 1024,
+            ..HttpDownloadConfig::default()
+        },
+        tx,
+        CancellationToken::new(),
+        Arc::new(Mutex::new(None)),
+        Arc::new(Mutex::new(None)),
+        None,
+        unlimited_semaphore(),
+        unlimited_throttle(),
+        runtime_tx,
+    )
+    .await;
+
+    match wait_for_runtime_update(&mut runtime_rx, |update| {
+        matches!(
+            update,
+            TaskRuntimeUpdate::ChunkMapStateChanged {
+                state: TransferChunkMapState::Http(_),
+                ..
+            }
+        )
+    })
+    .await
+    {
+        TaskRuntimeUpdate::ChunkMapStateChanged {
+            state: TransferChunkMapState::Http(snapshot),
+            ..
+        } => {
+            assert_eq!(snapshot.cells.len(), 128);
+            assert!(snapshot.cells.iter().all(|&cell| {
+                matches!(
+                    cell,
+                    ChunkMapCellState::Empty
+                        | ChunkMapCellState::Partial
+                        | ChunkMapCellState::Complete
+                )
+            }));
+        }
+        other => panic!("expected http chunk-map snapshot, got {other:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn single_stream_fallback_no_range_support() {
     let data = test_data(5_000);
     let expected_hash = sha256(&data);
@@ -170,6 +238,59 @@ async fn single_stream_fallback_no_range_support() {
 
     let downloaded = std::fs::read(&dest).unwrap();
     assert_eq!(sha256(&downloaded), expected_hash);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_range_http_emits_unsupported_chunk_map_state() {
+    let data = test_data(5_000);
+
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/file.bin"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(data))
+        .mount(&server)
+        .await;
+
+    let url = format!("{}/file.bin", server.uri());
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("file.bin");
+
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let (runtime_tx, mut runtime_rx) = runtime_updates_channel();
+    download_task(
+        DownloadId(0),
+        url,
+        dest,
+        exact_destination_policy(&dir.path().join("file.bin")),
+        HttpDownloadConfig::default(),
+        tx,
+        CancellationToken::new(),
+        Arc::new(Mutex::new(None)),
+        Arc::new(Mutex::new(None)),
+        None,
+        unlimited_semaphore(),
+        unlimited_throttle(),
+        runtime_tx,
+    )
+    .await;
+
+    match wait_for_runtime_update(&mut runtime_rx, |update| {
+        matches!(
+            update,
+            TaskRuntimeUpdate::ChunkMapStateChanged {
+                state: TransferChunkMapState::Unsupported,
+                ..
+            }
+        )
+    })
+    .await
+    {
+        TaskRuntimeUpdate::ChunkMapStateChanged {
+            state: TransferChunkMapState::Unsupported,
+            ..
+        } => {}
+        other => panic!("expected unsupported chunk-map state, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -254,6 +375,52 @@ async fn no_content_length_fallback_emits_narrowed_runtime_control_support() {
         saw_support_change,
         "expected runtime control-support narrowing"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn no_content_length_fallback_emits_unsupported_chunk_map_state() {
+    let data = test_data(2_000);
+    let server = spawn_no_content_length_server(data).await;
+    let url = format!("http://{server}/file.bin");
+    let dir = tempfile::tempdir().unwrap();
+    let dest = dir.path().join("file.bin");
+
+    let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+    let (runtime_tx, mut runtime_rx) = runtime_updates_channel();
+    download_task(
+        DownloadId(0),
+        url,
+        dest,
+        exact_destination_policy(&dir.path().join("file.bin")),
+        HttpDownloadConfig::default(),
+        tx,
+        CancellationToken::new(),
+        Arc::new(Mutex::new(None)),
+        Arc::new(Mutex::new(None)),
+        None,
+        unlimited_semaphore(),
+        unlimited_throttle(),
+        runtime_tx,
+    )
+    .await;
+
+    match wait_for_runtime_update(&mut runtime_rx, |update| {
+        matches!(
+            update,
+            TaskRuntimeUpdate::ChunkMapStateChanged {
+                state: TransferChunkMapState::Unsupported,
+                ..
+            }
+        )
+    })
+    .await
+    {
+        TaskRuntimeUpdate::ChunkMapStateChanged {
+            state: TransferChunkMapState::Unsupported,
+            ..
+        } => {}
+        other => panic!("expected unsupported chunk-map state, got {other:?}"),
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/tests/engine_notifications.rs
+++ b/tests/engine_notifications.rs
@@ -23,23 +23,9 @@ use ophelia::engine::destination::DestinationPolicy;
 use ophelia::engine::http::HttpDownloadConfig;
 use ophelia::engine::{
     ArtifactState, DownloadEngine, DownloadSpec, DownloadStatus, EngineNotification,
-    LiveTransferRemovalAction, TransferControlSupport,
+    LiveTransferRemovalAction, TransferChunkMapState, TransferControlSupport,
 };
 use ophelia::settings::Settings;
-
-fn wait_for_notification(engine: &mut DownloadEngine) -> EngineNotification {
-    let deadline = Instant::now() + Duration::from_secs(2);
-    loop {
-        if let Some(notification) = engine.poll_notification() {
-            return notification;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for engine notification"
-        );
-        std::thread::sleep(Duration::from_millis(10));
-    }
-}
 
 fn wait_for_matching_notification(
     engine: &mut DownloadEngine,
@@ -82,6 +68,63 @@ fn spawn_no_content_length_server(body: Vec<u8>) -> std::net::SocketAddr {
     addr
 }
 
+fn spawn_slow_range_server(
+    body: Vec<u8>,
+    chunk_size: usize,
+    delay: Duration,
+) -> std::net::SocketAddr {
+    use std::io::{Read, Write};
+
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    std::thread::spawn(move || {
+        for socket in listener.incoming() {
+            let Ok(mut socket) = socket else {
+                break;
+            };
+            let body = body.clone();
+            std::thread::spawn(move || {
+                let mut request = [0u8; 4096];
+                let bytes_read = socket.read(&mut request).unwrap_or(0);
+                let request = String::from_utf8_lossy(&request[..bytes_read]);
+                let range_header = request
+                    .lines()
+                    .find_map(|line| line.strip_prefix("Range: bytes="));
+
+                let (start, end) = if let Some(range) = range_header {
+                    let mut parts = range.trim().split('-');
+                    let start = parts.next().unwrap_or("0").parse::<usize>().unwrap_or(0);
+                    let end = parts
+                        .next()
+                        .and_then(|end| end.parse::<usize>().ok())
+                        .unwrap_or_else(|| body.len().saturating_sub(1))
+                        .min(body.len().saturating_sub(1));
+                    (start.min(end), end)
+                } else {
+                    (0, body.len().saturating_sub(1))
+                };
+
+                let payload = &body[start..=end];
+                let headers = format!(
+                    "HTTP/1.1 206 Partial Content\r\nContent-Range: bytes {}-{}/{}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                    start,
+                    end,
+                    body.len(),
+                    payload.len(),
+                );
+                let _ = socket.write_all(headers.as_bytes());
+
+                for chunk in payload.chunks(chunk_size.max(1)) {
+                    let _ = socket.write_all(chunk);
+                    let _ = socket.flush();
+                    std::thread::sleep(delay);
+                }
+            });
+        }
+    });
+    addr
+}
+
 #[test]
 fn queued_pause_resume_cancel_and_delete_emit_distinct_notifications() {
     let (db_tx, _db_rx) = std::sync::mpsc::channel();
@@ -101,7 +144,13 @@ fn queued_pause_resume_cancel_and_delete_emit_distinct_notifications() {
     ));
 
     engine.pause(id);
-    match wait_for_notification(&mut engine) {
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::Update(update)
+                if update.id == id && update.status == DownloadStatus::Paused
+        )
+    }) {
         EngineNotification::Update(update) => {
             assert_eq!(update.id, id);
             assert_eq!(update.status, DownloadStatus::Paused);
@@ -112,7 +161,13 @@ fn queued_pause_resume_cancel_and_delete_emit_distinct_notifications() {
     }
 
     engine.resume(id);
-    match wait_for_notification(&mut engine) {
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::Update(update)
+                if update.id == id && update.status == DownloadStatus::Pending
+        )
+    }) {
         EngineNotification::Update(update) => {
             assert_eq!(update.id, id);
             assert_eq!(update.status, DownloadStatus::Pending);
@@ -123,7 +178,12 @@ fn queued_pause_resume_cancel_and_delete_emit_distinct_notifications() {
     }
 
     engine.cancel(id);
-    match wait_for_notification(&mut engine) {
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::LiveTransferRemoved { id: removed, .. } if *removed == id
+        )
+    }) {
         EngineNotification::LiveTransferRemoved {
             id: removed,
             action,
@@ -144,7 +204,12 @@ fn queued_pause_resume_cancel_and_delete_emit_distinct_notifications() {
     ));
     std::fs::write(&destination, b"partial").unwrap();
     engine.delete_artifact(id, destination.clone());
-    match wait_for_notification(&mut engine) {
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::LiveTransferRemoved { id: removed, .. } if *removed == id
+        )
+    }) {
         EngineNotification::LiveTransferRemoved {
             id: removed,
             action,
@@ -196,5 +261,123 @@ fn single_stream_http_emits_runtime_control_support_narrowing() {
             );
         }
         other => panic!("expected control-support change, got {other:?}"),
+    }
+}
+
+#[test]
+fn chunked_http_emits_loading_snapshot_and_terminal_unsupported() {
+    let server = spawn_slow_range_server(vec![5u8; 32 * 1024], 512, Duration::from_millis(25));
+
+    let (db_tx, _db_rx) = std::sync::mpsc::channel();
+    let mut engine = DownloadEngine::new(Settings::default(), db_tx, 1);
+    let tempdir = tempfile::tempdir().unwrap();
+    let destination = tempdir.path().join("file.bin");
+    let id = engine.add(DownloadSpec::http(
+        format!("http://{server}/file.bin"),
+        destination.clone(),
+        DestinationPolicy::for_resolved_destination(&Settings::default(), &destination),
+        HttpDownloadConfig {
+            speed_limit_bps: 20_000,
+            write_buffer_size: 1024,
+            ..HttpDownloadConfig::default()
+        },
+    ));
+
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::ChunkMapStateChanged {
+                id: changed,
+                state: TransferChunkMapState::Loading,
+            } if *changed == id
+        )
+    }) {
+        EngineNotification::ChunkMapStateChanged {
+            id: changed,
+            state: TransferChunkMapState::Loading,
+        } => assert_eq!(changed, id),
+        other => panic!("expected loading chunk-map state, got {other:?}"),
+    }
+
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::ChunkMapStateChanged {
+                id: changed,
+                state: TransferChunkMapState::Http(_),
+            } if *changed == id
+        )
+    }) {
+        EngineNotification::ChunkMapStateChanged {
+            id: changed,
+            state: TransferChunkMapState::Http(snapshot),
+        } => {
+            assert_eq!(changed, id);
+            assert_eq!(snapshot.cells.len(), 128);
+        }
+        other => panic!("expected http chunk-map snapshot, got {other:?}"),
+    }
+
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::ChunkMapStateChanged {
+                id: changed,
+                state: TransferChunkMapState::Unsupported,
+            } if *changed == id
+        )
+    }) {
+        EngineNotification::ChunkMapStateChanged {
+            id: changed,
+            state: TransferChunkMapState::Unsupported,
+        } => assert_eq!(changed, id),
+        other => panic!("expected terminal unsupported chunk-map state, got {other:?}"),
+    }
+}
+
+#[test]
+fn pausing_active_http_clears_chunk_map_to_unsupported() {
+    let server = spawn_slow_range_server(vec![9u8; 32 * 1024], 512, Duration::from_millis(25));
+
+    let (db_tx, _db_rx) = std::sync::mpsc::channel();
+    let mut engine = DownloadEngine::new(Settings::default(), db_tx, 1);
+    let tempdir = tempfile::tempdir().unwrap();
+    let destination = tempdir.path().join("file.bin");
+    let id = engine.add(DownloadSpec::http(
+        format!("http://{server}/file.bin"),
+        destination.clone(),
+        DestinationPolicy::for_resolved_destination(&Settings::default(), &destination),
+        HttpDownloadConfig {
+            speed_limit_bps: 20_000,
+            write_buffer_size: 1024,
+            ..HttpDownloadConfig::default()
+        },
+    ));
+
+    let _ = wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::ChunkMapStateChanged {
+                id: changed,
+                state: TransferChunkMapState::Http(_),
+            } if *changed == id
+        )
+    });
+
+    engine.pause(id);
+    match wait_for_matching_notification(&mut engine, |notification| {
+        matches!(
+            notification,
+            EngineNotification::ChunkMapStateChanged {
+                id: changed,
+                state: TransferChunkMapState::Unsupported,
+            } if *changed == id
+        )
+    }) {
+        EngineNotification::ChunkMapStateChanged {
+            id: changed,
+            state: TransferChunkMapState::Unsupported,
+        } => assert_eq!(changed, id),
+        other => panic!("expected paused unsupported chunk-map state, got {other:?}"),
     }
 }


### PR DESCRIPTION
this is the backend part of the chunk map visualizer for the frontend, closes #51 